### PR TITLE
Adding Permissions Group for Instructors + Endorsement

### DIFF
--- a/public/openapi/read/category/category_id.yaml
+++ b/public/openapi/read/category/category_id.yaml
@@ -87,6 +87,8 @@ get:
                         type: boolean
                       isAdminOrMod:
                         type: boolean
+                      isInstructor:
+                        type: boolean
                   showSelect:
                     type: boolean
                   showTopicTools:

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -347,6 +347,8 @@ get:
                         type: boolean
                       isAdminOrMod:
                         type: boolean
+                      isInstructor:
+                        type: boolean
                       disabled:
                         type: number
                       tid:

--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -31,6 +31,7 @@ privsPosts.get = async function (pids, uid) {
         'posts:edit': helpers.isAllowedTo('posts:edit', uid, uniqueCids),
         'posts:history': helpers.isAllowedTo('posts:history', uid, uniqueCids),
         'posts:view_deleted': helpers.isAllowedTo('posts:view_deleted', uid, uniqueCids),
+        isInstruct: user.isInstructor(uid),
     });
 
     const isModerator = _.zipObject(uniqueCids, results.isModerator);
@@ -46,6 +47,7 @@ privsPosts.get = async function (pids, uid) {
         const editable = (privData['posts:edit'][cid] && (results.isOwner[i] || results.isModerator)) || results.isAdmin;
         const viewDeletedPosts = results.isOwner[i] || privData['posts:view_deleted'][cid] || results.isAdmin;
         const viewHistory = results.isOwner[i] || privData['posts:history'][cid] || results.isAdmin;
+        const isInstructor = results.isInstruct;
 
         return {
             editable: editable,
@@ -55,6 +57,7 @@ privsPosts.get = async function (pids, uid) {
             read: privData.read[cid] || results.isAdmin,
             'posts:history': viewHistory,
             'posts:view_deleted': viewDeletedPosts,
+            isInstructor: isInstructor
         };
     });
 

--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -57,7 +57,7 @@ privsPosts.get = async function (pids, uid) {
             read: privData.read[cid] || results.isAdmin,
             'posts:history': viewHistory,
             'posts:view_deleted': viewDeletedPosts,
-            isInstructor: isInstructor
+            isInstructor: isInstructor,
         };
     });
 

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -22,11 +22,12 @@ privsTopics.get = async function (tid, uid) {
         'posts:delete', 'posts:view_deleted', 'read', 'purge',
     ];
     const topicData = await topics.getTopicFields(tid, ['cid', 'uid', 'locked', 'deleted', 'scheduled']);
-    const [userPrivileges, isAdministrator, isModerator, disabled] = await Promise.all([
+    const [userPrivileges, isAdministrator, isModerator, disabled, isInstruct] = await Promise.all([
         helpers.isAllowedTo(privs, uid, topicData.cid),
         user.isAdministrator(uid),
         user.isModerator(uid, topicData.cid),
         categories.getCategoryField(topicData.cid, 'disabled'),
+        user.isInstructor(uid),
     ]);
     const privData = _.zipObject(privs, userPrivileges);
     const isOwner = uid > 0 && uid === topicData.uid;
@@ -34,6 +35,7 @@ privsTopics.get = async function (tid, uid) {
     const editable = isAdminOrMod;
     const deletable = (privData['topics:delete'] && (isOwner || isModerator)) || isAdministrator;
     const mayReply = privsTopics.canViewDeletedScheduled(topicData, {}, false, privData['topics:schedule']);
+    const isInstructor = isInstruct;
 
     return await plugins.hooks.fire('filter:privileges.topics.get', {
         'topics:reply': (privData['topics:reply'] && ((!topicData.locked && mayReply) || isModerator)) || isAdministrator,
@@ -54,6 +56,7 @@ privsTopics.get = async function (tid, uid) {
         view_deleted: isAdminOrMod || isOwner || privData['posts:view_deleted'],
         view_scheduled: privData['topics:schedule'] || isAdministrator,
         isAdminOrMod: isAdminOrMod,
+        isInstructor: isInstructor,
         disabled: disabled,
         tid: tid,
         uid: uid,
@@ -172,6 +175,10 @@ privsTopics.isAdminOrMod = async function (tid, uid) {
     }
     const cid = await topics.getTopicField(tid, 'cid');
     return await privsCategories.isAdminOrMod(cid, uid);
+};
+
+privsTopics.isInstructor = async function (uid) {
+    return await privsCategories.isInstructor(uid);
 };
 
 privsTopics.canViewDeletedScheduled = function (topic, privileges = {}, viewDeleted = false, viewScheduled = false) {

--- a/src/privileges/users.js
+++ b/src/privileges/users.js
@@ -19,6 +19,11 @@ privsUsers.isGlobalModerator = async function (uid) {
     return await isGroupMember(uid, 'Global Moderators');
 };
 
+privsUsers.isInstructor = async function (uid) {
+    const accountType = await user.getUserField(uid, 'accounttype');
+    return accountType === 'instructor';
+};
+
 async function isGroupMember(uid, groupName) {
     return await groups[Array.isArray(uid) ? 'isMembers' : 'isMember'](uid, groupName);
 }

--- a/src/user/index.js
+++ b/src/user/index.js
@@ -153,6 +153,10 @@ User.isGlobalModerator = async function (uid) {
     return await privileges.users.isGlobalModerator(uid);
 };
 
+User.isInstructor = async function (uid) {
+    return await privileges.users.isInstructor(uid);
+};
+
 User.getPrivileges = async function (uid) {
     return await utils.promiseParallel({
         isAdmin: User.isAdministrator(uid),

--- a/themes/nodebb-theme-persona/templates/account/profile.tpl
+++ b/themes/nodebb-theme-persona/templates/account/profile.tpl
@@ -86,6 +86,11 @@
             <span>[[user:age]]</span>
             <strong>{age}</strong>
             <!-- ENDIF age -->
+
+            <!-- IF accounttype -->
+            <span>User is a </span>
+            <strong>{accounttype}</strong>
+            <!-- ENDIF accounttype -->
         </div>
     </div>
 

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -82,7 +82,9 @@
             <span component="post/endorsement-text" class="<!-- IF !posts.endorsed -->hidden<!-- ENDIF !posts.endorsed -->">[[topic:post_endorsed]]</span>
         </a>
         <span class="post-tools">
-            <a component="post/endorse" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:endorse]]</a>
+            <!-- IF privileges.isInstructor -->
+                <a component="post/endorse" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:endorse]]</a>
+            <!-- ENDIF privileges.isInstructor -->
             <a component="post/reply" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:reply]]</a>
             <a component="post/quote" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:quote]]</a>
         </span>


### PR DESCRIPTION
Adding permissions for the endorsement button so that only instructors can see and press the endorse button. Students now can only see if a post is endorsed, not the button itself. This involved adding a new permission group for instructors and making changes to the front-end functionality of the endorse feature.  Solves #32. 

Below is a screenshot to show the new UI.

UI for students:
<img width="1172" alt="Screenshot 2024-02-29 at 1 33 15 PM" src="https://github.com/CMU-313/spring24-nodebb-git-goons/assets/42014313/1bcf8c18-46c9-43a0-9ee9-464f2de8635b">

UI for instructors:
<img width="1196" alt="Screenshot 2024-02-29 at 1 32 55 PM" src="https://github.com/CMU-313/spring24-nodebb-git-goons/assets/42014313/d339a270-bd57-4bbc-a573-9ee2817e2ec7">