### PR TITLE
Added Static Analysis tool StandardJS

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -81,3 +81,6 @@ jobs:
 
       - name: Run ESLint
         run: npm run lint
+
+      - name: Run standard
+        run: npx standard 

--- a/install/package.json
+++ b/install/package.json
@@ -12,6 +12,7 @@
     "scripts": {
         "start": "npx tsc && node loader.js",
         "lint": "npx tsc && eslint --cache ./nodebb .",
+        "standard": "standard",
         "test": "npx tsc && nyc --reporter=html --reporter=text-summary mocha",
         "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
         "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage"
@@ -129,6 +130,7 @@
         "sortablejs": "1.15.0",
         "spdx-license-list": "6.6.0",
         "spider-detector": "2.0.0",
+        "standard": "*",
         "terser-webpack-plugin": "5.3.6",
         "textcomplete": "0.18.2",
         "textcomplete.contenteditable": "0.1.1",


### PR DESCRIPTION
Added StandardJS, which is a JavaScript style guide, linter, and formatted. It automatically formats code and can catch style issues + programmer errors early, saving time during code reviews. It also requires no configuration. 

StandardJS is added to the Lint GitHub workflow and can be run on the command line using 'npx standard'. 

Here is a screenshot showing the output of running StandardJS on our code base:  
<img width="1253" alt="Screenshot 2024-03-14 at 2 51 45 PM" src="https://github.com/CMU-313/spring24-nodebb-git-goons/assets/42014313/8b4e4b31-fa64-4884-9191-7b134fde84c2">